### PR TITLE
fix(macos): Add @loader_path to libjniDTLV.dylib for libdtlv.dylib reference

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -56,7 +56,13 @@ jobs:
             cd ../src/java
             java -jar ~/.m2/repository/org/bytedeco/javacpp/1.5.12/javacpp-1.5.12.jar datalevin/dtlvnative/DTLV.java
 
-            cd ../..
+            # Fix libjniDTLV.dylib to use @loader_path for libdtlv.dylib reference
+            # Without this fix, dlopen fails when libraries are extracted to temp directory
+            cd datalevin/dtlvnative/macosx-arm64
+            install_name_tool -change libdtlv.dylib @loader_path/libdtlv.dylib libjniDTLV.dylib
+            codesign -f -s - libjniDTLV.dylib
+
+            cd ../../..
             cp src/java/datalevin/dtlvnative/macosx-arm64/*.dylib macosx-arm64/resources/datalevin/dtlvnative/macosx-arm64/
 
             cd macosx-arm64


### PR DESCRIPTION
## Problem

On macOS ARM64, applications using Datalevin fail at runtime with:

```
java.lang.UnsatisfiedLinkError: Can't load library: jniDTLV
Caused by: dlopen(.../libjniDTLV.dylib): Library not loaded: libdtlv.dylib
```

## Root Cause

The JavaCPP-generated `libjniDTLV.dylib` references `libdtlv.dylib` using a bare library name instead of `@loader_path/libdtlv.dylib`. When JavaCPP extracts libraries to a temp directory, macOS's dyld cannot find `libdtlv.dylib`.

Before:

```sh
$ otool -L libjniDTLV.dylib
    libdtlv.dylib (compatibility version 0.0.0)  ← bare name
```

## Solution

Add post-processing after JavaCPP generation:

```sh
install_name_tool -change libdtlv.dylib @loader_path/libdtlv.dylib libjniDTLV.dylib
codesign -f -s - libjniDTLV.dylib
```

After:

```sh
$ otool -L libjniDTLV.dylib
    @loader_path/libdtlv.dylib (compatibility version 0.0.0)  ← fixed
```

Consistency

This follows the same pattern used for libomp.dylib in script/build-macos (lines 60-69).

Testing

- macOS ARM64 (Apple Silicon)
- Datalevin 0.9.27
- Both JVM and GraalVM native-image modes work after fix

Related

Partially addresses #335
https://github.com/juji-io/datalevin/issues/335