### PR TITLE
remove `-static-libgcc` ldflag 

### DIFF
--- a/script/build
+++ b/script/build
@@ -106,7 +106,7 @@ cmake --build build_release --config Release
 
 # build lmdb and dtlv
 
-export LDFLAGS="${LDFLAGS:+$LDFLAGS }-static-libstdc++ -static-libgcc -Wl,-rpath,'$$ORIGIN'"
+export LDFLAGS="${LDFLAGS:+$LDFLAGS }-static-libstdc++ -Wl,-rpath,'$$ORIGIN'"
 export OMP_LIB="-fopenmp"
 export USEARCH_LIB="-Wl,--whole-archive -lusearch -Wl,--no-whole-archive"
 


### PR DESCRIPTION
because the flag accidentally increased the minimum glibc requirement from 2.34 to 2.35
(because GCC 12's `libgcc.a` on the build machine i.e Ubuntu 22.04 baked in a reference to the newer `_dl_find_object` )

as discussed in the Clojurian's Slack: https://clojurians.slack.com/archives/C01RD3AF336/p1774669800281149

I also ran a script on both control (master) and fix (this PR) to see the version number of GLIBC symbols used, and can confirm that this change makes it so that no GLIBC_2.35 symbols have sneaked in
<img width="1083" height="623" alt="image" src="https://github.com/user-attachments/assets/5872b65d-d84e-47cb-9997-6fc2346c9364" />

I also checked the script on a Ubuntu 24.04 build and realized that if we keep `-static-libgcc`, then on upgrading the build script to that Ubuntu version, minimum glibc that supports datalevin would then jump up to 2.38
<img width="483" height="227" alt="image" src="https://github.com/user-attachments/assets/ca7f90ed-b99d-422f-b72e-71662af7d1a6" />
